### PR TITLE
fix sexp2mic

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -86,9 +86,8 @@ utility = {
     return hex;
   },
   sexp2mic : function me (mi){
-    if (mi.charAt(0) == "(") mi = mi.slice(1,-1);
+    if (mi.charAt(0) === "(") mi = mi.slice(1,-1);
     var pl = 0;
-    var isString = false;
     var sopen = false;
     var escaped = false;
     var ret = {
@@ -102,8 +101,8 @@ utility = {
         escaped = false;
         continue;
       }
-      else if ((i == (mi.length - 1) && sopen == false) || (mi[i] == " " && pl == 0 && sopen == false)){
-        if (i == (mi.length - 1)) val += mi[i];
+      else if ((i === (mi.length - 1) && sopen === false) || (mi[i] === " " && pl === 0 && sopen === false)){
+        if (i === (mi.length - 1)) val += mi[i];
         if (val){
           if (val === parseInt(val).toString()) {
             if (!ret.prim) return {"int" : val}
@@ -117,20 +116,20 @@ utility = {
         }
         continue;
       }
-      else if (mi[i] == '"' && sopen) {
+      else if (mi[i] === '"' && sopen) {
         sopen = false;  
         if (!ret.prim) return {'string':val};
         else ret.args.push({'string':val});
         val = '';
         continue;
       }
-      else if (mi[i] == '"' && !sopen) {
+      else if (mi[i] === '"' && !sopen && pl === 0) {
         sopen = true;
         continue;
       }
-      else if (mi[i] == '\\') escaped = true;
-      else if (mi[i] == "(") pl++;  
-      else if (mi[i] == ")") pl--;
+      else if (mi[i] === '\\') escaped = true;
+      else if (mi[i] === "(") pl++;  
+      else if (mi[i] === ")") pl--;
       val += mi[i];
     }
     return ret;

--- a/src/main.js
+++ b/src/main.js
@@ -86,6 +86,9 @@ utility = {
     return hex;
   },
   sexp2mic : function me (mi){
+    str = str.replace(/(?:@[a-z_]+)|(?:#.*$)/mg, '')
+          .replace(/\s+/g, ' ')
+          .trim();
     if (mi.charAt(0) === "(") mi = mi.slice(1,-1);
     var pl = 0;
     var sopen = false;

--- a/src/main.js
+++ b/src/main.js
@@ -86,7 +86,7 @@ utility = {
     return hex;
   },
   sexp2mic : function me (mi){
-    str = str.replace(/(?:@[a-z_]+)|(?:#.*$)/mg, '')
+    mi = mi.replace(/(?:@[a-z_]+)|(?:#.*$)/mg, '')
           .replace(/\s+/g, ' ')
           .trim();
     if (mi.charAt(0) === "(") mi = mi.slice(1,-1);


### PR DESCRIPTION
Strings containing parentheses now get parsed correctly, e.g.:
`eztz.utility.sexp2mic('Right (Pair "e6b752ebb26bded9c1540a218b4cd5d2aab12be1fcb1947dabb75cef0bf0c811782930476be93c65a938844039340ddf7c91ed43f7f24b817ec634d3871d8206" (Pair "2018-01-16T15:52:08Z" (Pair (Pair (Pair "265.00" "8.35") (Pair (Pair 377749 -1224194) "2018-01-17T19:15:58Z")) "edpktkGZSCkejnEsxmiT2QGRni5s7uLKwzuPpZjZ8wPZHmZxuA3cag")))')`