### PR TITLE
Fix typo so that tz3 signature prefix does not overwrite tz2 prefix

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ const defaultProvider = "http://45.56.83.80:3000",
   prefix = {
     tz1: new Uint8Array([6, 161, 159]),
     tz2: new Uint8Array([6, 161, 161]),
-    tz2: new Uint8Array([6, 161, 164]),
+    tz3: new Uint8Array([6, 161, 164]),
     KT: new Uint8Array([2,90,121]),
     
     


### PR DESCRIPTION
I'm assuming this is a typo.

Separate issue, but would be nice if we could clean up the lock files and tests. I got a ton of diffs with both yarn and npm on lts and tests couldn't find jest for me.